### PR TITLE
Build commit with an actually updated appdata.xml

### DIFF
--- a/net.drawpile.drawpile.yaml
+++ b/net.drawpile.drawpile.yaml
@@ -74,9 +74,9 @@ modules:
       - -DTESTS=off
       - -DTOOLS=off
       - -DUSE_STRICT_ALIASING=on
+      - -DBUILD_VERSION=2.2.0
     sources:
       - type: git
         url: https://github.com/drawpile/Drawpile.git
-        tag: 2.2.0
-        commit: b0e343eae8a9707ba5ec6f2f3d57e18d62fe3359
+        commit: 3f831b387fa5778420a0ae189bd07b000e8b3f66
       - cargo-sources.json


### PR DESCRIPTION
And specifying the version manually. Because the way our CI works, pushing a tag is what triggers the build for the artifacts, which means we don't have the hashes for them until *after* that version tag, which in turn is needed to update the appdata.xml with them.